### PR TITLE
Support for allOrNothing & Fixed Postgres default schema subscriber

### DIFF
--- a/src/DI/MigrationsExtension.php
+++ b/src/DI/MigrationsExtension.php
@@ -42,6 +42,7 @@ final class MigrationsExtension extends CompilerExtension
 				Configuration::VERSIONS_ORGANIZATION_BY_YEAR_AND_MONTH
 			),
 			'customTemplate' => Expect::string(),
+            'allOrNothing' => Expect::bool(false)
 		]);
 	}
 
@@ -62,7 +63,8 @@ final class MigrationsExtension extends CompilerExtension
 			->setFactory(Configuration::class)
 			->addSetup('setCustomTemplate', [$config->customTemplate])
 			->addSetup('setMetadataStorageConfiguration', [$storage])
-			->addSetup('addMigrationsDirectory', [$config->namespace, $config->directory]);
+			->addSetup('addMigrationsDirectory', [$config->namespace, $config->directory])
+            ->addSetup('setAllOrNothing', [$config->allOrNothing]);;
 
 		if ($config->versionsOrganization === Configuration::VERSIONS_ORGANIZATION_BY_YEAR) {
 			$configuration->addSetup('setMigrationsAreOrganizedByYear');

--- a/src/Subscriber/FixPostgreSQLDefaultSchemaSubscriber.php
+++ b/src/Subscriber/FixPostgreSQLDefaultSchemaSubscriber.php
@@ -23,7 +23,7 @@ final class FixPostgreSQLDefaultSchemaSubscriber implements EventSubscriber
 		$schemaManager = $args
 			->getEntityManager()
 			->getConnection()
-			->createSchemaManager();
+			->getSchemaManager();
 
 		if (!$schemaManager instanceof PostgreSQLSchemaManager) {
 			return;


### PR DESCRIPTION
- Added support for allOrNothing config option (https://www.doctrine-project.org/projects/doctrine-migrations/en/3.3/reference/configuration.html#configuration)

- Fixed  Call to undefined method Doctrine\DBAL\Connection::createSchemaManager() in PostgresSQLDefaultSchemaSubscriber