### PR TITLE
Resolve #41

### DIFF
--- a/.github/workflows/codesniffer.yml
+++ b/.github/workflows/codesniffer.yml
@@ -15,4 +15,4 @@ jobs:
     name: "Codesniffer"
     uses: contributte/.github/.github/workflows/codesniffer.yml@master
     with:
-      php: "8.3"
+      php: "8.4"

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -15,4 +15,4 @@ jobs:
     name: "Nette Tester"
     uses: contributte/.github/.github/workflows/nette-tester-coverage-v2.yml@master
     with:
-      php: "8.3"
+      php: "8.4"

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -15,4 +15,4 @@ jobs:
     name: "Phpstan"
     uses: contributte/.github/.github/workflows/phpstan.yml@master
     with:
-      php: "8.3"
+      php: "8.4"

--- a/composer.json
+++ b/composer.json
@@ -9,10 +9,6 @@
     {
       "name": "Milan Felix Šulc",
       "homepage": "https://f3l1x.io"
-    },
-    {
-      "name": "Josef Benjac",
-      "homepage": "http://josefbenjac.com"
     }
   ],
   "require": {
@@ -26,6 +22,7 @@
     "contributte/qa": "^0.4.0",
     "contributte/tester": "^0.4.0",
     "contributte/phpstan": "^0.2.0",
+    "psr/log": "^3.0",
     "symfony/console": "^7.2.0"
   },
   "autoload": {

--- a/src/DI/MigrationsExtension.php
+++ b/src/DI/MigrationsExtension.php
@@ -18,6 +18,7 @@ use Doctrine\Migrations\Tools\Console\Command\StatusCommand;
 use Doctrine\Migrations\Tools\Console\Command\SyncMetadataCommand;
 use Doctrine\Migrations\Tools\Console\Command\UpToDateCommand;
 use Doctrine\Migrations\Tools\Console\Command\VersionCommand;
+use Doctrine\Migrations\Version\Comparator;
 use Doctrine\Migrations\Version\MigrationFactory;
 use Nette\DI\CompilerExtension;
 use Nette\DI\Definitions\Statement;
@@ -53,6 +54,7 @@ final class MigrationsExtension extends CompilerExtension
 			'allOrNothing' => Expect::bool(false),
 			'logger' => (clone $expectService),
 			'migrationFactory' => (clone $expectService),
+			'comparator' => (clone $expectService),
 			'connection' => Expect::string(),
 			'manager' => Expect::string(),
 		]);
@@ -103,72 +105,76 @@ final class MigrationsExtension extends CompilerExtension
 			$dependencyFactory->addSetup('setService', [MigrationFactory::class, SmartStatement::from($config->migrationFactory)]);
 		}
 
+		if ($config->comparator !== null) {
+			$dependencyFactory->addSetup('setService', [Comparator::class, SmartStatement::from($config->comparator)]);
+		}
+
 		// Register commands
 
 		$builder->addDefinition($this->prefix('currentCommand'))
 			->setFactory(CurrentCommand::class)
 			->setAutowired(false)
-			->addTag('console.command', CurrentCommand::getDefaultName());
+			->addTag('console.command', 'migrations:current');
 
 		$builder->addDefinition($this->prefix('diffCommand'))
 			->setFactory(DiffCommand::class)
 			->setAutowired(false)
-			->addTag('console.command', DiffCommand::getDefaultName());
+			->addTag('console.command', 'migrations:diff');
 
 		$builder->addDefinition($this->prefix('dumpSchemaCommand'))
 			->setFactory(DumpSchemaCommand::class)
 			->setAutowired(false)
-			->addTag('console.command', DumpSchemaCommand::getDefaultName());
+			->addTag('console.command', 'migrations:dump-schema');
 
 		$builder->addDefinition($this->prefix('executeCommand'))
 			->setFactory(ExecuteCommand::class)
 			->setAutowired(false)
-			->addTag('console.command', ExecuteCommand::getDefaultName());
+			->addTag('console.command', 'migrations:execute');
 
 		$builder->addDefinition($this->prefix('generateCommand'))
 			->setFactory(GenerateCommand::class)
 			->setAutowired(false)
-			->addTag('console.command', GenerateCommand::getDefaultName());
+			->addTag('console.command', 'migrations:generate');
 
 		$builder->addDefinition($this->prefix('latestCommand'))
 			->setFactory(LatestCommand::class)
 			->setAutowired(false)
-			->addTag('console.command', LatestCommand::getDefaultName());
+			->addTag('console.command', 'migrations:latest');
 
 		$builder->addDefinition($this->prefix('listCommand'))
 			->setFactory(ListCommand::class)
 			->setAutowired(false)
-			->addTag('console.command', ListCommand::getDefaultName());
+			->addTag('console.command', 'migrations:list');
 
 		$builder->addDefinition($this->prefix('migrateCommand'))
 			->setFactory(MigrateCommand::class)
 			->setAutowired(false)
-			->addTag('console.command', MigrateCommand::getDefaultName());
+			->addTag('console.command', 'migrations:migrate');
 
 		$builder->addDefinition($this->prefix('rollupCommand'))
 			->setFactory(RollupCommand::class)
 			->setAutowired(false)
-			->addTag('console.command', RollupCommand::getDefaultName());
+			->addTag('console.command', 'migrations:rollup');
 
 		$builder->addDefinition($this->prefix('statusCommand'))
 			->setFactory(StatusCommand::class)
 			->setAutowired(false)
-			->addTag('console.command', StatusCommand::getDefaultName());
+			->addTag('console.command', 'migrations:status');
 
 		$builder->addDefinition($this->prefix('syncMetadataCommand'))
 			->setFactory(SyncMetadataCommand::class)
 			->setAutowired(false)
-			->addTag('console.command', SyncMetadataCommand::getDefaultName());
+			->addTag('console.command', 'migrations:sync-metadata-storage');
 
 		$builder->addDefinition($this->prefix('upToDateCommand'))
 			->setFactory(UpToDateCommand::class)
 			->setAutowired(false)
-			->addTag('console.command', UpToDateCommand::getDefaultName());
+			->addTag('console.command', 'migrations:up-to-date');
 
 		$builder->addDefinition($this->prefix('versionCommand'))
 			->setFactory(VersionCommand::class)
 			->setAutowired(false)
-			->addTag('console.command', VersionCommand::getDefaultName());
+			->addTag('console.command', 'migrations:version');
 	}
 
 }

--- a/tests/Cases/DI/MigrationsExtension.comparator.phpt
+++ b/tests/Cases/DI/MigrationsExtension.comparator.phpt
@@ -1,0 +1,87 @@
+<?php declare(strict_types = 1);
+
+namespace Tests\Cases\Unit\DI;
+
+use Contributte\Tester\Toolkit;
+use Contributte\Tester\Utils\ContainerBuilder;
+use Contributte\Tester\Utils\Neonkit;
+use Doctrine\Migrations\DependencyFactory;
+use Doctrine\Migrations\Version\AlphabeticalComparator;
+use Nette\DI\Compiler;
+use Nettrine\Migrations\DI\MigrationsExtension;
+use Tester\Assert;
+use Tests\Mocks\DummyComparator;
+
+require_once __DIR__ . '/../../bootstrap.php';
+
+// Custom comparator
+Toolkit::test(function (): void {
+	$container = ContainerBuilder::of()
+		->withCompiler(function (Compiler $compiler): void {
+			$compiler->addExtension('migrations', new MigrationsExtension());
+			$compiler->addConfig(Neonkit::load('
+				migrations:
+					directories:
+						App\Domain: /root/migrations
+					comparator: Tests\Mocks\DummyComparator
+				services:
+					- Symfony\Component\Console\Application
+					- Doctrine\DBAL\Driver\Mysqli\Driver
+					- Doctrine\DBAL\Connection([])
+					- Tests\Mocks\DummyConnectionRegistry
+			'));
+		})
+		->build();
+
+	/** @var DependencyFactory $dependencyFactory */
+	$dependencyFactory = $container->getByType(DependencyFactory::class);
+	Assert::type(DummyComparator::class, $dependencyFactory->getVersionComparator());
+});
+
+// Custom comparator via service reference
+Toolkit::test(function (): void {
+	$container = ContainerBuilder::of()
+		->withCompiler(function (Compiler $compiler): void {
+			$compiler->addExtension('migrations', new MigrationsExtension());
+			$compiler->addConfig(Neonkit::load('
+				migrations:
+					directories:
+						App\Domain: /root/migrations
+					comparator: @customComparator
+				services:
+					customComparator: Tests\Mocks\DummyComparator
+					- Symfony\Component\Console\Application
+					- Doctrine\DBAL\Driver\Mysqli\Driver
+					- Doctrine\DBAL\Connection([])
+					- Tests\Mocks\DummyConnectionRegistry
+			'));
+		})
+		->build();
+
+	/** @var DependencyFactory $dependencyFactory */
+	$dependencyFactory = $container->getByType(DependencyFactory::class);
+	Assert::type(DummyComparator::class, $dependencyFactory->getVersionComparator());
+});
+
+// Default comparator (AlphabeticalComparator) when no custom comparator is configured
+Toolkit::test(function (): void {
+	$container = ContainerBuilder::of()
+		->withCompiler(function (Compiler $compiler): void {
+			$compiler->addExtension('migrations', new MigrationsExtension());
+			$compiler->addConfig(Neonkit::load('
+				migrations:
+					directories:
+						App\Domain: /root/migrations
+				services:
+					- Symfony\Component\Console\Application
+					- Doctrine\DBAL\Driver\Mysqli\Driver
+					- Doctrine\DBAL\Connection([])
+					- Tests\Mocks\DummyConnectionRegistry
+			'));
+		})
+		->build();
+
+	/** @var DependencyFactory $dependencyFactory */
+	$dependencyFactory = $container->getByType(DependencyFactory::class);
+	Assert::type(AlphabeticalComparator::class, $dependencyFactory->getVersionComparator());
+});

--- a/tests/Cases/DI/MigrationsExtension.configuration.phpt
+++ b/tests/Cases/DI/MigrationsExtension.configuration.phpt
@@ -1,0 +1,147 @@
+<?php declare(strict_types = 1);
+
+namespace Tests\Cases\Unit\DI;
+
+use Contributte\Tester\Toolkit;
+use Contributte\Tester\Utils\ContainerBuilder;
+use Contributte\Tester\Utils\Neonkit;
+use Doctrine\Migrations\Configuration\Configuration;
+use Doctrine\Migrations\Metadata\Storage\TableMetadataStorageConfiguration;
+use Nette\DI\Compiler;
+use Nettrine\Migrations\DI\MigrationsExtension;
+use Tester\Assert;
+
+require_once __DIR__ . '/../../bootstrap.php';
+
+// Custom table and column name
+Toolkit::test(function (): void {
+	$container = ContainerBuilder::of()
+		->withCompiler(function (Compiler $compiler): void {
+			$compiler->addExtension('migrations', new MigrationsExtension());
+			$compiler->addConfig(Neonkit::load('
+				migrations:
+					table: custom_migrations_table
+					column: migration_version
+					directories:
+						App\Domain: /root/migrations
+				services:
+					- Symfony\Component\Console\Application
+					- Doctrine\DBAL\Driver\Mysqli\Driver
+					- Doctrine\DBAL\Connection([])
+					- Tests\Mocks\DummyConnectionRegistry
+			'));
+		})
+		->build();
+
+	/** @var Configuration $configuration */
+	$configuration = $container->getByType(Configuration::class);
+
+	/** @var TableMetadataStorageConfiguration|null $storageConfig */
+	$storageConfig = $configuration->getMetadataStorageConfiguration();
+	Assert::type(TableMetadataStorageConfiguration::class, $storageConfig);
+	Assert::same('custom_migrations_table', $storageConfig->getTableName());
+	Assert::same('migration_version', $storageConfig->getVersionColumnName());
+});
+
+// Versions organization by year
+Toolkit::test(function (): void {
+	$container = ContainerBuilder::of()
+		->withCompiler(function (Compiler $compiler): void {
+			$compiler->addExtension('migrations', new MigrationsExtension());
+			$compiler->addConfig(Neonkit::load('
+				migrations:
+					directories:
+						App\Domain: /root/migrations
+					versionsOrganization: year
+				services:
+					- Symfony\Component\Console\Application
+					- Doctrine\DBAL\Driver\Mysqli\Driver
+					- Doctrine\DBAL\Connection([])
+					- Tests\Mocks\DummyConnectionRegistry
+			'));
+		})
+		->build();
+
+	/** @var Configuration $configuration */
+	$configuration = $container->getByType(Configuration::class);
+	Assert::true($configuration->areMigrationsOrganizedByYear());
+	Assert::false($configuration->areMigrationsOrganizedByYearAndMonth());
+});
+
+// Versions organization by year and month
+Toolkit::test(function (): void {
+	$container = ContainerBuilder::of()
+		->withCompiler(function (Compiler $compiler): void {
+			$compiler->addExtension('migrations', new MigrationsExtension());
+			$compiler->addConfig(Neonkit::load('
+				migrations:
+					directories:
+						App\Domain: /root/migrations
+					versionsOrganization: year_and_month
+				services:
+					- Symfony\Component\Console\Application
+					- Doctrine\DBAL\Driver\Mysqli\Driver
+					- Doctrine\DBAL\Connection([])
+					- Tests\Mocks\DummyConnectionRegistry
+			'));
+		})
+		->build();
+
+	/** @var Configuration $configuration */
+	$configuration = $container->getByType(Configuration::class);
+	Assert::true($configuration->areMigrationsOrganizedByYearAndMonth());
+});
+
+// allOrNothing configuration
+Toolkit::test(function (): void {
+	$container = ContainerBuilder::of()
+		->withCompiler(function (Compiler $compiler): void {
+			$compiler->addExtension('migrations', new MigrationsExtension());
+			$compiler->addConfig(Neonkit::load('
+				migrations:
+					directories:
+						App\Domain: /root/migrations
+					allOrNothing: true
+				services:
+					- Symfony\Component\Console\Application
+					- Doctrine\DBAL\Driver\Mysqli\Driver
+					- Doctrine\DBAL\Connection([])
+					- Tests\Mocks\DummyConnectionRegistry
+			'));
+		})
+		->build();
+
+	/** @var Configuration $configuration */
+	$configuration = $container->getByType(Configuration::class);
+	Assert::true($configuration->isAllOrNothing());
+});
+
+// Multiple migration directories
+Toolkit::test(function (): void {
+	$container = ContainerBuilder::of()
+		->withCompiler(function (Compiler $compiler): void {
+			$compiler->addExtension('migrations', new MigrationsExtension());
+			$compiler->addConfig(Neonkit::load('
+				migrations:
+					directories:
+						App\Migrations: /app/migrations
+						App\CoreMigrations: /core/migrations
+						Vendor\PackageMigrations: /vendor/package/migrations
+				services:
+					- Symfony\Component\Console\Application
+					- Doctrine\DBAL\Driver\Mysqli\Driver
+					- Doctrine\DBAL\Connection([])
+					- Tests\Mocks\DummyConnectionRegistry
+			'));
+		})
+		->build();
+
+	/** @var Configuration $configuration */
+	$configuration = $container->getByType(Configuration::class);
+	$directories = $configuration->getMigrationDirectories();
+
+	Assert::count(3, $directories);
+	Assert::same('/app/migrations', $directories['App\\Migrations']);
+	Assert::same('/core/migrations', $directories['App\\CoreMigrations']);
+	Assert::same('/vendor/package/migrations', $directories['Vendor\\PackageMigrations']);
+});

--- a/tests/Cases/DI/MigrationsExtension.factory.phpt
+++ b/tests/Cases/DI/MigrationsExtension.factory.phpt
@@ -1,0 +1,39 @@
+<?php declare(strict_types = 1);
+
+namespace Tests\Cases\Unit\DI;
+
+use Contributte\Tester\Toolkit;
+use Contributte\Tester\Utils\ContainerBuilder;
+use Contributte\Tester\Utils\Neonkit;
+use Doctrine\Migrations\DependencyFactory;
+use Nette\DI\Compiler;
+use Nettrine\Migrations\DI\MigrationsExtension;
+use Tester\Assert;
+use Tests\Mocks\DummyMigrationFactory;
+
+require_once __DIR__ . '/../../bootstrap.php';
+
+// Custom migration factory
+Toolkit::test(function (): void {
+	$container = ContainerBuilder::of()
+		->withCompiler(function (Compiler $compiler): void {
+			$compiler->addExtension('migrations', new MigrationsExtension());
+			$compiler->addConfig(Neonkit::load('
+				migrations:
+					directories:
+						App\Domain: /root/migrations
+					migrationFactory: Tests\Mocks\DummyMigrationFactory
+				services:
+					- Symfony\Component\Console\Application
+					- Doctrine\DBAL\Driver\Mysqli\Driver
+					- Doctrine\DBAL\Connection([])
+					- Tests\Mocks\DummyConnectionRegistry
+					- Psr\Log\NullLogger
+			'));
+		})
+		->build();
+
+	/** @var DependencyFactory $dependencyFactory */
+	$dependencyFactory = $container->getByType(DependencyFactory::class);
+	Assert::type(DummyMigrationFactory::class, $dependencyFactory->getMigrationFactory());
+});

--- a/tests/Cases/DI/MigrationsExtension.logger.phpt
+++ b/tests/Cases/DI/MigrationsExtension.logger.phpt
@@ -1,0 +1,62 @@
+<?php declare(strict_types = 1);
+
+namespace Tests\Cases\Unit\DI;
+
+use Contributte\Tester\Toolkit;
+use Contributte\Tester\Utils\ContainerBuilder;
+use Contributte\Tester\Utils\Neonkit;
+use Doctrine\Migrations\DependencyFactory;
+use Nette\DI\Compiler;
+use Nettrine\Migrations\DI\MigrationsExtension;
+use Psr\Log\NullLogger;
+use Tester\Assert;
+use Tests\Mocks\DummyLogger;
+
+require_once __DIR__ . '/../../bootstrap.php';
+
+// Custom logger
+Toolkit::test(function (): void {
+	$container = ContainerBuilder::of()
+		->withCompiler(function (Compiler $compiler): void {
+			$compiler->addExtension('migrations', new MigrationsExtension());
+			$compiler->addConfig(Neonkit::load('
+				migrations:
+					directories:
+						App\Domain: /root/migrations
+				services:
+					- Symfony\Component\Console\Application
+					- Doctrine\DBAL\Driver\Mysqli\Driver
+					- Doctrine\DBAL\Connection([])
+					- Tests\Mocks\DummyConnectionRegistry
+					- Tests\Mocks\DummyLogger
+			'));
+		})
+		->build();
+
+	/** @var DependencyFactory $dependencyFactory */
+	$dependencyFactory = $container->getByType(DependencyFactory::class);
+	Assert::type(DummyLogger::class, $dependencyFactory->getLogger());
+});
+
+// Default logger (NullLogger) when no custom logger is configured
+Toolkit::test(function (): void {
+	$container = ContainerBuilder::of()
+		->withCompiler(function (Compiler $compiler): void {
+			$compiler->addExtension('migrations', new MigrationsExtension());
+			$compiler->addConfig(Neonkit::load('
+				migrations:
+					directories:
+						App\Domain: /root/migrations
+				services:
+					- Symfony\Component\Console\Application
+					- Doctrine\DBAL\Driver\Mysqli\Driver
+					- Doctrine\DBAL\Connection([])
+					- Tests\Mocks\DummyConnectionRegistry
+			'));
+		})
+		->build();
+
+	/** @var DependencyFactory $dependencyFactory */
+	$dependencyFactory = $container->getByType(DependencyFactory::class);
+	Assert::type(NullLogger::class, $dependencyFactory->getLogger());
+});

--- a/tests/Mocks/DummyComparator.php
+++ b/tests/Mocks/DummyComparator.php
@@ -1,0 +1,31 @@
+<?php declare(strict_types = 1);
+
+namespace Tests\Mocks;
+
+use Doctrine\Migrations\Version\Comparator;
+use Doctrine\Migrations\Version\Version;
+
+/**
+ * A custom comparator for testing that compares migrations by class name only,
+ * ignoring the namespace (useful for ordering migrations from different namespaces).
+ */
+final class DummyComparator implements Comparator
+{
+
+	public function compare(Version $a, Version $b): int
+	{
+		// Extract class name without namespace
+		$classA = $this->getClassName((string) $a);
+		$classB = $this->getClassName((string) $b);
+
+		return strcmp($classA, $classB);
+	}
+
+	private function getClassName(string $fullyQualifiedName): string
+	{
+		$parts = explode('\\', $fullyQualifiedName);
+
+		return end($parts);
+	}
+
+}

--- a/tests/Mocks/DummyLogger.php
+++ b/tests/Mocks/DummyLogger.php
@@ -1,0 +1,29 @@
+<?php declare(strict_types = 1);
+
+namespace Tests\Mocks;
+
+use Psr\Log\AbstractLogger;
+use Stringable;
+
+/**
+ * A custom logger for testing.
+ */
+final class DummyLogger extends AbstractLogger
+{
+
+	/** @var array<array{level: string, message: string, context: mixed[]}> */
+	public array $logs = [];
+
+	/**
+	 * @param mixed[] $context
+	 */
+	public function log(mixed $level, string|Stringable $message, array $context = []): void
+	{
+		$this->logs[] = [
+			'level' => (string) $level,
+			'message' => (string) $message,
+			'context' => $context,
+		];
+	}
+
+}

--- a/tests/Mocks/DummyMigrationFactory.php
+++ b/tests/Mocks/DummyMigrationFactory.php
@@ -1,0 +1,28 @@
+<?php declare(strict_types = 1);
+
+namespace Tests\Mocks;
+
+use Doctrine\DBAL\Connection;
+use Doctrine\Migrations\AbstractMigration;
+use Doctrine\Migrations\Version\MigrationFactory;
+use Psr\Log\LoggerInterface;
+
+/**
+ * A custom migration factory for testing.
+ */
+final class DummyMigrationFactory implements MigrationFactory
+{
+
+	public function __construct(
+		private Connection $connection,
+		private LoggerInterface $logger
+	)
+	{
+	}
+
+	public function createVersion(string $migrationClassName): AbstractMigration
+	{
+		return new $migrationClassName($this->connection, $this->logger);
+	}
+
+}


### PR DESCRIPTION
Resolves #41 - allow custom version Comparator configuration via .neon

- Add comparator config option to MigrationsExtension
- Add test cases for custom comparator configuration
- Add test cases for custom migration factory configuration
- Add test cases for table/column, versionsOrganization, allOrNothing
- Add test cases for multiple migration directories
- Add test cases for custom logger configuration
- Add test mocks: DummyComparator, DummyMigrationFactory, DummyLogger